### PR TITLE
Update to org.freedesktop.Platform//19.08

### DIFF
--- a/com.tux4kids.tuxmath.json
+++ b/com.tux4kids.tuxmath.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.tux4kids.tuxmath",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "1.6",
+    "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=dri",
@@ -42,6 +42,10 @@
                 {
                     "type": "patch",
                     "path": "t4kcommon-libpng16.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "t4kcommon-libxml2-frame-count.patch"
                 },
                 {
                     "type": "script",

--- a/t4kcommon-libxml2-frame-count.patch
+++ b/t4kcommon-libxml2-frame-count.patch
@@ -1,0 +1,96 @@
+From 9ec08c5413cf23c41b244527c9a843d4dd36dafa Mon Sep 17 00:00:00 2001
+From: Paul Huff <paul.huff@gmail.com>
+Date: Wed, 1 May 2019 19:56:12 -0600
+Subject: [PATCH] Use libxml2 to get info from svg files for frame counts since
+ librsvg doesn't let you access the description anymore.
+
+https://github.com/tux4kids/t4kcommon/pull/5
+
+Modified-by: Will Thompson <will@willthompson.co.uk>
+
+(Removed irrelevant configure.ac hunk; rectified whitespace mismatch)
+---
+ src/t4k_loaders.c | 45 +++++++++++++++++++++++++++++++++++++++++++--
+ 2 files changed, 44 insertions(+), 3 deletions(-)
+
+diff --git a/src/t4k_loaders.c b/src/t4k_loaders.c
+index f69e5e5..495c7c8 100644
+--- a/src/t4k_loaders.c
++++ b/src/t4k_loaders.c
+@@ -41,6 +41,8 @@ static void savePNG(SDL_Surface* surf,char* fn); //TODO this could be part of th
+ #ifdef HAVE_RSVG
+ #include<librsvg/rsvg.h>
+ #include<librsvg/rsvg-cairo.h>
++#include <libxml/parser.h>
++#include <libxml/tree.h>
+ #endif
+ 
+ #define SOUNDS_DIR "sounds"
+@@ -49,6 +51,7 @@ static void savePNG(SDL_Surface* surf,char* fn); //TODO this could be part of th
+ /* local functions */
+ 
+ #ifdef HAVE_RSVG
++int             get_number_of_frames_from_svg(const char *file_name);
+ SDL_Surface*    load_svg(const char* file_name, int width, int height, const char* layer_name);
+ sprite*         load_svg_sprite(const char* file_name, int width, int height);
+ SDL_Surface*    render_svg_from_handle(RsvgHandle* file_handle, int width, int height, const char* layer_name);
+@@ -165,6 +168,45 @@ const char* find_file(const char* base_name)
+ }
+ #ifdef HAVE_RSVG
+ 
++int get_number_of_frames_from_svg(const char* file_name) {
++    xmlDocPtr svgFile;
++    xmlNodePtr svgNode = NULL, nodeIterator = NULL;
++    int number_of_frames = 0, found = 0;
++
++    svgFile = xmlReadFile(file_name, NULL, XML_PARSE_RECOVER | XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
++
++    /* If it's null something's really wrong because we're trying to load a sprite that doesn't exist */
++    if(svgFile == NULL) {
++        DEBUGMSG(debug_loaders, "get_number_of_frames_from_svg: couldn't load svgFile: %s\n", file_name);
++        return 0;
++    }
++
++    svgNode = xmlDocGetRootElement(svgFile);
++
++    /* If it's null then something's really wrong because there should be a root in every svg file... */
++    if(svgNode == NULL) {
++        DEBUGMSG(debug_loaders, "get_number_of_frames_from_svg: couldn't load the root from the svgFile: %s", file_name);
++        xmlFreeDoc(svgFile); /* be clean */
++        return 0;
++    }
++
++    nodeIterator = svgNode->children;
++    while(nodeIterator) {
++        if(xmlStrcasecmp(nodeIterator->name, (const xmlChar*)"desc") == 0) {
++            sscanf((const char*)xmlNodeGetContent(nodeIterator), "%d", &number_of_frames);
++            xmlFreeDoc(svgFile);
++            return number_of_frames;
++        }
++        nodeIterator = nodeIterator->next;
++    }
++
++    /* if we get here we had no description, which means something's really wrong */
++    DEBUGMSG(debug_loaders, "get_number_of_frames_from_svg: couldn't find the description frame number count from svgFile: %s", file_name);
++    xmlFreeDoc(svgFile);
++    return 0;
++}
++
++
+ /* Load a layer of SVG file and resize it to given dimensions.
+    If width or height is negative no resizing is applied.
+    If layer = NULL then the whole image is loaded.
+@@ -225,7 +267,7 @@ sprite* load_svg_sprite(const char* file_name, int width, int height)
+   new_sprite->default_img = render_svg_from_handle(file_handle, width, height, "#default");
+ 
+   /* get number of frames from description */
+-  sscanf(rsvg_handle_get_desc(file_handle), "%d", &new_sprite->num_frames);
++  new_sprite->num_frames = get_number_of_frames_from_svg(file_name);
+   DEBUGMSG(debug_loaders, "load_svg_sprite(): loading %d frames\n", new_sprite->num_frames);
+ 
+   for(i = 0; i < new_sprite->num_frames; i++)
+@@ -1163,4 +1205,3 @@ Mix_Music* T4K_LoadMusic(char *datafile )
+     }
+     return tempMusic;
+ }
+-

--- a/tuxmath.appdata.xml
+++ b/tuxmath.appdata.xml
@@ -15,7 +15,7 @@
      school tournaments and similar competitions.
     </p>
   </description>
-  <url type="homepage">https://tux4kids.alioth.debian.org/tuxmath/index.php</url>
+  <url type="homepage">https://github.com/tux4kids/tuxmath</url>
   <screenshots>
     <screenshot>https://github.com/flathub/com.tux4kids.tuxmath/raw/baf090f14fb397bbd0b6c7702f07820277694e10/screenshots/help.jpg</screenshot>
     <screenshot type="default">https://github.com/flathub/com.tux4kids.tuxmath/raw/baf090f14fb397bbd0b6c7702f07820277694e10/screenshots/game_play.jpg</screenshot>


### PR DESCRIPTION
Includes a backport of https://github.com/tux4kids/t4kcommon/pull/5 to deal with rsvg_handle_get_desc() always returning NULL in modern librsvg, and an appdata tweak.

https://github.com/flathub/flathub/issues/667