### PR TITLE
Update to 21.08 runtime

### DIFF
--- a/com.tux4kids.tuxmath.json
+++ b/com.tux4kids.tuxmath.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.tux4kids.tuxmath",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "19.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=dri",
@@ -33,6 +33,10 @@
         {
             "name": "t4kcommon",
             "rm-configure": true,
+            "build-options": {
+                "cflags": "-fcommon",
+                "cxxflags": "-fcommon"
+            },
             "sources": [
                 {
                     "type": "archive",
@@ -59,6 +63,10 @@
         {
             "name": "tuxmath",
             "rm-configure": true,
+            "build-options": {
+                "cflags": "-fcommon",
+                "cxxflags": "-fcommon"
+            },
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Based on @hfiguiere's patch for tuxtype,
https://github.com/flathub/com.tux4kids.tuxtype/pull/9/commits/e3b3fee02301e4e4457214153d3f3e66a93f6354,
with the same `-fcommon` workaround for the main app too.
